### PR TITLE
Fix: restrict workflow token permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,11 @@ on:
   pull_request:
     branches: [main]
 
+# Least-privilege default for all jobs; both jobs only read the
+# repository contents (checkout). Individual jobs override as needed.
+permissions:
+  contents: read
+
 jobs:
   test-job:
     name: Test hw-bom GitHub Action TypeScript 🧪


### PR DESCRIPTION
## Pull request overview

Zizmor's regular-persona audit (the configuration used by the
organisation-level scheduled scan) reported three `excessive-permissions`
findings in `.github/workflows/main.yml`. This change resolves them,
bringing the repository to zero medium-or-higher findings.

### Changes

- **excessive-permissions:** the workflow declared no `permissions:`
  block, so the workflow itself and both the `test-job` and `dogfood`
  jobs ran with the default, overly broad `GITHUB_TOKEN` permission
  set. A top-level `permissions: contents: read` block is added. Both
  jobs only read the repository (checkout, plus npm build and a
  self-dogfood run of the action); no job writes to the repository, so
  a single least-privilege read grant covers them with no per-job
  override required.

### Impact

No functional change to the test or dogfood jobs.

### Validation

- `zizmor --persona regular --min-severity medium` now reports **no
  findings**.
- `yamllint` and `actionlint` pass on the changed workflow (two
  pre-existing `document-start`/`truthy` style warnings on the `on:`
  block are unrelated to this change and left untouched).