### PR TITLE
Fix: pin picomatch to 4.0.5 everywhere via overrides (GHSA-3v7f-55p6-f55p)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5569,19 +5569,6 @@
         "fsevents": "^2.3.3"
       }
     },
-    "node_modules/jest-haste-map/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/jest-leak-detector": {
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.4.1.tgz",
@@ -5632,19 +5619,6 @@
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-message-util/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/jest-mock": {
@@ -5854,19 +5828,6 @@
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-util/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/jest-validate": {
@@ -6534,13 +6495,13 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -7202,19 +7163,6 @@
         "picomatch": {
           "optional": true
         }
-      }
-    },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/tmpl": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,9 @@
     "@types/bunyan": "^1.8.11",
     "bunyan": "^1.8.15"
   },
+  "overrides": {
+    "picomatch": "4.0.5"
+  },
   "devDependencies": {
     "@actions/core": "^3.0.1",
     "@actions/github": "^9.1.1",


### PR DESCRIPTION
## Problem

Dependabot alert [#30](https://github.com/lfreleng-actions/hw-bom-javascript/security/dependabot/30) (GHSA-3v7f-55p6-f55p, medium): **`picomatch < 2.3.2`** — method injection in POSIX character classes causing incorrect glob matching. The affected copy is `picomatch@2.3.1`, pulled in transitively (dev scope) via `jest > jest-haste-map > anymatch@3.1.3 > picomatch@^2.0.4`.

## Fix

Instead of leaving the 2.x line at 2.3.2 next to the 4.x copies used by jest/tinyglobby, add an npm `overrides` entry pinning **picomatch to 4.0.5 everywhere**. This dedupes the tree to a single picomatch version and removes the vulnerable copy entirely.

```json
"overrides": { "picomatch": "4.0.5" }
```

The lockfile collapses from 5 picomatch copies (one 2.3.1 + four 4.0.x) to a single 4.0.5.

## Compatibility note

`anymatch@3.1.3` declares `picomatch@^2.0.4`, so this override forces it past its declared range. anymatch is unmaintained (2021) but only uses the stable two-argument `picomatch(pattern, options)` form. Verified it still matches correctly under 4.0.5 — globs, globstar, negation, character classes, regex matchers, and `returnIndex` all pass — and the full jest suite is green.

## Verification

- `npm ci` — clean.
- `npm run check-all` — format-check, lint, test (14/14), build all pass.
- Single `picomatch@4.0.5` in the tree; picomatch no longer appears in `npm audit`.

Supersedes #215 (which kept the 2.x line at 2.3.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)