### PR TITLE
Fix: clean up aislop console-leftover and hardcoded-url findings

### DIFF
--- a/dist/instrumentation.js
+++ b/dist/instrumentation.js
@@ -20,20 +20,21 @@ const sdk = new NodeSDK({
         [ATTR_SERVICE_VERSION]: '1.0.0'
     }),
     logRecordProcessors: [
-        new SimpleLogRecordProcessor(new OTLPLogExporter({
-            url: otelExporterOTLPEndpoint + '/v1/logs',
-            headers: { otelExporterOTLPHeaders }
-        })),
-        new SimpleLogRecordProcessor(new ConsoleLogRecordExporter())
+        new SimpleLogRecordProcessor({
+            exporter: new OTLPLogExporter({
+                url: otelExporterOTLPEndpoint + '/v1/logs',
+                headers: { otelExporterOTLPHeaders }
+            })
+        }),
+        new SimpleLogRecordProcessor({ exporter: new ConsoleLogRecordExporter() })
     ],
     instrumentations: [new BunyanInstrumentation()]
 });
 try {
     sdk.start();
-    console.log('OpenTelemetry SDK started');
-    console.log('Sending logs to:', otelExporterOTLPEndpoint);
-    console.log('Using headers:', otelExporterOTLPHeaders);
+    core.info('OpenTelemetry SDK started');
+    core.info(`Sending logs to: ${otelExporterOTLPEndpoint}`);
 }
 catch (error) {
-    console.error('Error starting OpenTelemetry SDK:', error);
+    core.error(`Error starting OpenTelemetry SDK: ${error instanceof Error ? error.message : String(error)}`);
 }

--- a/dist/main.js
+++ b/dist/main.js
@@ -10,6 +10,12 @@ import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic
 import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
 import bunyan from 'bunyan';
 import { LoggerProvider, SimpleLogRecordProcessor } from '@opentelemetry/sdk-logs';
+// Cloud Instance Metadata Service (IMDS) endpoints. These are fixed,
+// provider-defined addresses rather than environment-specific configuration:
+// 169.254.169.254 is the link-local IMDS address used by AWS, Azure and
+// OpenStack; metadata.google.internal is the GCP metadata server.
+const IMDS_LINK_LOCAL = 'http://169.254.169.254';
+const GCP_METADATA_SERVER = 'http://metadata.google.internal';
 const serviceName = core.getInput('otel_service_name') || 'github-actions-hw-bom';
 const resource = resourceFromAttributes({
     [ATTR_SERVICE_NAME]: serviceName,
@@ -27,7 +33,7 @@ const otlpExporter = new OTLPLogExporter({
 });
 const loggerProvider = new LoggerProvider({
     resource: resource,
-    processors: [new SimpleLogRecordProcessor(otlpExporter)]
+    processors: [new SimpleLogRecordProcessor({ exporter: otlpExporter })]
 });
 const logger = bunyan.createLogger({
     name: serviceName,
@@ -64,7 +70,7 @@ logger.addStream({
 });
 export async function getAwsToken() {
     try {
-        const response = await fetch('http://169.254.169.254/latest/api/token', {
+        const response = await fetch(`${IMDS_LINK_LOCAL}/latest/api/token`, {
             method: 'PUT',
             headers: { 'X-aws-ec2-metadata-token-ttl-seconds': '21600' }
         });
@@ -79,21 +85,21 @@ export async function getInstanceType(cloud, awsToken = '') {
     try {
         switch (cloud) {
             case 'aws': {
-                const awsResponse = await fetch('http://169.254.169.254/latest/meta-data/instance-type', { headers: { 'X-aws-ec2-metadata-token': awsToken } });
+                const awsResponse = await fetch(`${IMDS_LINK_LOCAL}/latest/meta-data/instance-type`, { headers: { 'X-aws-ec2-metadata-token': awsToken } });
                 return await awsResponse.text();
             }
             case 'azure': {
-                const azureResponse = await fetch('http://169.254.169.254/metadata/instance/compute/vmSize?api-version=2021-02-01&format=text', { headers: { Metadata: 'true' } });
+                const azureResponse = await fetch(`${IMDS_LINK_LOCAL}/metadata/instance/compute/vmSize?api-version=2021-02-01&format=text`, { headers: { Metadata: 'true' } });
                 const azureData = await azureResponse.text();
                 return azureData;
             }
             case 'gce': {
-                const gceResponse = await fetch('http://metadata.google.internal/computeMetadata/v1/instance/machine-type', { headers: { 'Metadata-Flavor': 'Google' } });
+                const gceResponse = await fetch(`${GCP_METADATA_SERVER}/computeMetadata/v1/instance/machine-type`, { headers: { 'Metadata-Flavor': 'Google' } });
                 const gceData = (await gceResponse.text()).split('/').pop() || '';
                 return gceData;
             }
             case 'openstack': {
-                const openstackResponse = await fetch('http://169.254.169.254/2009-04-04/meta-data/instance-type');
+                const openstackResponse = await fetch(`${IMDS_LINK_LOCAL}/2009-04-04/meta-data/instance-type`);
                 return await openstackResponse.text();
             }
             default:

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -44,9 +44,10 @@ const sdk = new NodeSDK({
 
 try {
   sdk.start()
-  console.log('OpenTelemetry SDK started')
-  console.log('Sending logs to:', otelExporterOTLPEndpoint)
-  console.log('Using headers:', otelExporterOTLPHeaders)
+  core.info('OpenTelemetry SDK started')
+  core.info(`Sending logs to: ${otelExporterOTLPEndpoint}`)
 } catch (error) {
-  console.error('Error starting OpenTelemetry SDK:', error)
+  core.error(
+    `Error starting OpenTelemetry SDK: ${error instanceof Error ? error.message : String(error)}`
+  )
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,13 @@ import bunyan from 'bunyan'
 import {LoggerProvider, SimpleLogRecordProcessor} from '@opentelemetry/sdk-logs'
 import {ValueType} from '@opentelemetry/api'
 
+// Cloud Instance Metadata Service (IMDS) endpoints. These are fixed,
+// provider-defined addresses rather than environment-specific configuration:
+// 169.254.169.254 is the link-local IMDS address used by AWS, Azure and
+// OpenStack; metadata.google.internal is the GCP metadata server.
+const IMDS_LINK_LOCAL = 'http://169.254.169.254'
+const GCP_METADATA_SERVER = 'http://metadata.google.internal'
+
 const serviceName =
   core.getInput('otel_service_name') || 'github-actions-hw-bom'
 const resource = resourceFromAttributes({
@@ -93,7 +100,7 @@ logger.addStream({
 
 export async function getAwsToken(): Promise<string> {
   try {
-    const response = await fetch('http://169.254.169.254/latest/api/token', {
+    const response = await fetch(`${IMDS_LINK_LOCAL}/latest/api/token`, {
       method: 'PUT',
       headers: {'X-aws-ec2-metadata-token-ttl-seconds': '21600'}
     })
@@ -112,14 +119,14 @@ export async function getInstanceType(
     switch (cloud) {
       case 'aws': {
         const awsResponse = await fetch(
-          'http://169.254.169.254/latest/meta-data/instance-type',
+          `${IMDS_LINK_LOCAL}/latest/meta-data/instance-type`,
           {headers: {'X-aws-ec2-metadata-token': awsToken}}
         )
         return await awsResponse.text()
       }
       case 'azure': {
         const azureResponse = await fetch(
-          'http://169.254.169.254/metadata/instance/compute/vmSize?api-version=2021-02-01&format=text',
+          `${IMDS_LINK_LOCAL}/metadata/instance/compute/vmSize?api-version=2021-02-01&format=text`,
           {headers: {Metadata: 'true'}}
         )
         const azureData = await azureResponse.text()
@@ -127,7 +134,7 @@ export async function getInstanceType(
       }
       case 'gce': {
         const gceResponse = await fetch(
-          'http://metadata.google.internal/computeMetadata/v1/instance/machine-type',
+          `${GCP_METADATA_SERVER}/computeMetadata/v1/instance/machine-type`,
           {headers: {'Metadata-Flavor': 'Google'}}
         )
         const gceData = (await gceResponse.text()).split('/').pop() || ''
@@ -135,7 +142,7 @@ export async function getInstanceType(
       }
       case 'openstack': {
         const openstackResponse = await fetch(
-          'http://169.254.169.254/2009-04-04/meta-data/instance-type'
+          `${IMDS_LINK_LOCAL}/2009-04-04/meta-data/instance-type`
         )
         return await openstackResponse.text()
       }


### PR DESCRIPTION
Addresses the open **aislop** code-scanning alerts in `src/`.

## `console-leftover` — #19, #20, #21 (`instrumentation.ts`)
Replaced the leftover `console.log` calls with `core.info()` and the `console.error` with `core.error()` (the `@actions/core` logger is already imported — idiomatic logging for a GitHub Action). **Dropped the `console.log('Using headers:', otelExporterOTLPHeaders)` line entirely**, since those headers can carry the OTLP auth token (e.g. `x-honeycomb-team=<key>`) and shouldn't be printed to the action log.

## `hardcoded-url` — #22, #23, #24 (`main.ts`)
These flag the cloud **Instance Metadata Service** endpoints — fixed, provider-defined addresses (`169.254.169.254` link-local for AWS/Azure/OpenStack; `metadata.google.internal` for GCP) that must be hardcoded. Extracted them into named, documented constants (`IMDS_LINK_LOCAL`, `GCP_METADATA_SERVER`) and built the request URLs from them — documents intent and removes the repeated literal.

## `hallucinated-import` — #25 (`eslint.config.mjs`)
Already resolved by #214 (`globals` / `@eslint/js` / `@eslint/eslintrc` are now declared in `package.json`). The alert last scanned a pre-#214 commit and will auto-close on the next scan — no change needed here.

## `dist/` rebuilt
The action runs the committed `dist/index.js`, so `dist/` is rebuilt from `src/` per repo convention. This also brings `dist/` back in sync with the `SimpleLogRecordProcessor({ exporter })` change from #211, whose merge had updated only `src/`.

## Verification
`npm ci` + `npm run check-all` (format-check, lint, test 14/14, build) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)