### PR TITLE
Fix: Bump shell-quote and brace-expansion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3495,9 +3495,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -4867,9 +4867,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6804,9 +6804,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "bunyan": "^1.8.15"
   },
   "overrides": {
-    "picomatch": "4.0.5"
+    "picomatch": "4.0.5",
+    "shell-quote": "1.10.0"
   },
   "devDependencies": {
     "@actions/core": "^3.0.1",


### PR DESCRIPTION
## Summary

Resolves three open Dependabot alerts (#61, #62, #63) flagging
denial-of-service vulnerabilities in transitive development
dependencies detected in `package-lock.json`:

| Alert | Package | Advisory | Vulnerable | Patched |
| ----- | ------- | -------- | ---------- | ------- |
| #63 | shell-quote | GHSA-395f-4hp3-45gv (CWE-407) | <= 1.8.4 | 1.9.0+ |
| #62 | brace-expansion | GHSA-3jxr-9vmj-r5cp | >= 2.0.0, < 2.1.2 | 2.1.2 |
| #61 | brace-expansion | GHSA-3jxr-9vmj-r5cp | < 1.1.16 | 1.1.16 |

## Changes

- **shell-quote → 1.10.0**: even the latest `concurrently` release
  (10.0.3) pins `shell-quote` to the vulnerable exact version `1.8.4`,
  so an npm `overrides` entry is added in `package.json` forcing
  `1.10.0` until upstream updates its pin
- **brace-expansion 1.1.12 → 1.1.16** and **2.1.1 → 2.1.2**: in-range
  transitive updates applied via the lockfile

All patched versions satisfy the 7-day `minimum-release-age`
supply-chain cooldown enforced in `.npmrc`.

## Validation

- `npm run check-all` (format-check, lint, test, build) passes
- `npm audit` reports 0 vulnerabilities
- Pre-commit (prek) hooks pass
