### PR TITLE
Fix: Env-mediate expressions in run blocks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,10 @@
+---
 # SPDX-FileCopyrightText: 2025 2025 The Linux Foundation
 #
 # SPDX-License-Identifier: Apache-2.0
 
 name: Test hw-bom GitHub Action 🧪
+# yamllint disable-line rule:truthy
 on:
   workflow_call:
     inputs:
@@ -106,15 +108,28 @@ jobs:
 
       - name: Display Hardware Information 🖥️
         run: |
-          echo "Cloud Provider: ${{ steps.hw-info.outputs.cloud }}"
-          echo "Instance Type: ${{ steps.hw-info.outputs.instanceType }}"
-          echo "Workflow RunID: ${{ steps.hw-info.outputs.workflowRun }}"
-          echo "CPU: ${{ steps.hw-info.outputs.cpu }}"
-          echo "CPU Vendor: ${{ steps.hw-info.outputs.cpuVendor }}"
-          echo "CPU Cores: ${{ steps.hw-info.outputs.cpuNumProc }}"
-          echo "GPU Vendor: ${{ steps.hw-info.outputs.gpuVendor }}"
-          echo "GPU Model: ${{ steps.hw-info.outputs.gpuModel }}"
-          echo "Memory: ${{ steps.hw-info.outputs.memTotal }}"
-          echo "Disk Total: ${{ steps.hw-info.outputs.diskTotal }}"
-          echo "Disk Used: ${{ steps.hw-info.outputs.diskUsed }}"
-          echo "Disk Free: ${{ steps.hw-info.outputs.diskFree }}"
+          echo "Cloud Provider: ${STEPS_HW_INFO_OUTPUTS_CLOUD}"
+          echo "Instance Type: ${STEPS_HW_INFO_OUTPUTS_INSTANCETYPE}"
+          echo "Workflow RunID: ${STEPS_HW_INFO_OUTPUTS_WORKFLOWRUN}"
+          echo "CPU: ${STEPS_HW_INFO_OUTPUTS_CPU}"
+          echo "CPU Vendor: ${STEPS_HW_INFO_OUTPUTS_CPUVENDOR}"
+          echo "CPU Cores: ${STEPS_HW_INFO_OUTPUTS_CPUNUMPROC}"
+          echo "GPU Vendor: ${STEPS_HW_INFO_OUTPUTS_GPUVENDOR}"
+          echo "GPU Model: ${STEPS_HW_INFO_OUTPUTS_GPUMODEL}"
+          echo "Memory: ${STEPS_HW_INFO_OUTPUTS_MEMTOTAL}"
+          echo "Disk Total: ${STEPS_HW_INFO_OUTPUTS_DISKTOTAL}"
+          echo "Disk Used: ${STEPS_HW_INFO_OUTPUTS_DISKUSED}"
+          echo "Disk Free: ${STEPS_HW_INFO_OUTPUTS_DISKFREE}"
+        env:
+          STEPS_HW_INFO_OUTPUTS_CLOUD: ${{ steps.hw-info.outputs.cloud }}
+          STEPS_HW_INFO_OUTPUTS_INSTANCETYPE: ${{ steps.hw-info.outputs.instanceType }}
+          STEPS_HW_INFO_OUTPUTS_WORKFLOWRUN: ${{ steps.hw-info.outputs.workflowRun }}
+          STEPS_HW_INFO_OUTPUTS_CPU: ${{ steps.hw-info.outputs.cpu }}
+          STEPS_HW_INFO_OUTPUTS_CPUVENDOR: ${{ steps.hw-info.outputs.cpuVendor }}
+          STEPS_HW_INFO_OUTPUTS_CPUNUMPROC: ${{ steps.hw-info.outputs.cpuNumProc }}
+          STEPS_HW_INFO_OUTPUTS_GPUVENDOR: ${{ steps.hw-info.outputs.gpuVendor }}
+          STEPS_HW_INFO_OUTPUTS_GPUMODEL: ${{ steps.hw-info.outputs.gpuModel }}
+          STEPS_HW_INFO_OUTPUTS_MEMTOTAL: ${{ steps.hw-info.outputs.memTotal }}
+          STEPS_HW_INFO_OUTPUTS_DISKTOTAL: ${{ steps.hw-info.outputs.diskTotal }}
+          STEPS_HW_INFO_OUTPUTS_DISKUSED: ${{ steps.hw-info.outputs.diskUsed }}
+          STEPS_HW_INFO_OUTPUTS_DISKFREE: ${{ steps.hw-info.outputs.diskFree }}

--- a/action.yml
+++ b/action.yml
@@ -1,3 +1,4 @@
+---
 # SPDX-FileCopyrightText: 2025 2025 The Linux Foundation
 #
 # SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
## Why

`zizmor`'s `template-injection` audit reports GitHub expressions that expand directly inside `run:` blocks. The expansion happens *before* the shell sees the script, so a value carrying shell syntax becomes code rather than data.

Each expression now reaches the shell through the step environment instead. These findings predate the change to the organisation `zizmor` floor (`low` → `informational`); they were simply below the old threshold.

## Please review the diff carefully

The transformation is not purely mechanical. Swapping `${{ expr }}` for `${VAR}` **changes the quoting rules**, because the original was substituted by GitHub before the shell ran and the replacement is an ordinary shell variable. Three contexts silently stop working:

| Context | Before | After |
| ------- | ------ | ----- |
| `var='${{ expr }}'` | substituted by GitHub | **literal string** |
| `echo 'text ${{ expr }}'` | substituted by GitHub | **literal string** |
| `cat <<'EOF'` … `${{ expr }}` | substituted by GitHub | **literal string** |

`shellcheck` catches the first two. **It does not catch the heredoc case.** That one was found in `url-validity-action`, where 27 references would have rendered the job summary as variable names instead of results.

## What was verified before raising this

- `zizmor --persona auditor --min-severity informational` — no findings
- `actionlint` (including shellcheck) — clean
- `yamllint` — clean
- A purpose-built audit for generated variables landing in single quotes or quoted heredocs — clean. It was validated by confirming it detects 33 such problems in the unrepaired output for `url-validity-action`.
- Diff restricted to workflow and action definitions; no `dependabot.yml` or version-pin comment changes rode along

## Note on the generated names

Where `zizmor`'s names push a line past the length limit, the line carries a `yamllint disable-line` directive. Shortening them was rejected: the short forms are unique only *within* one `env:` block, so a global rewrite merges distinct variables and leaves dangling references — verified by observing exactly that failure.
