### PR TITLE
Chore: Mark GCP metadata URL as intentional

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,7 @@ import {ValueType} from '@opentelemetry/api'
 // 169.254.169.254 is the link-local IMDS address used by AWS, Azure and
 // OpenStack; metadata.google.internal is the GCP metadata server.
 const IMDS_LINK_LOCAL = 'http://169.254.169.254'
+// aislop-ignore-next-line ai-slop/hardcoded-url -- fixed GCP-defined IMDS hostname, not deployment config
 const GCP_METADATA_SERVER = 'http://metadata.google.internal'
 
 const serviceName =


### PR DESCRIPTION
## AI slop scan fixes

Resolves the single aislop finding in this repository (1 medium), taking the score to 100 with zero diagnostics.

### Finding addressed

| Rule | Location | Fix |
| --- | --- | --- |
| `ai-slop/hardcoded-url` | `src/main.ts:25` | Inline suppression with reason |

The flagged value is `http://metadata.google.internal` — the fixed, GCP-defined instance metadata (IMDS) server hostname. Like the link-local `169.254.169.254` address beside it, this is a provider constant rather than deployment-specific configuration, so making it configurable would be misleading. The finding is suppressed inline with `aislop-ignore-next-line` and an explanatory reason.

`aislop scan` reports 100/100 with 0 diagnostics.